### PR TITLE
Fix Prototype Pollution

### DIFF
--- a/lib/apply.js
+++ b/lib/apply.js
@@ -15,6 +15,9 @@ module.exports = function apply(target, patch) {
   var keys = Object.keys(patch);
   for (var i = 0; i < keys.length; i++) {
     var key = keys[i];
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+      return target;
+    }
     if (patch[key] === null) {
       if (target.hasOwnProperty(key)) {
         delete target[key];


### PR DESCRIPTION
### 📊 Metadata *

json-merge-patch is vulnerable to Prototype Pollution.
This package fails to restrict access to prototypes of objects, allowing for modification of prototype behavior using a proto payload, which may result in Information Disclosure/DoS/RCE.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-json-merge-patch

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as _proto_, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes.

### 🐛 Proof of Concept (PoC) *

1. Install the package(npm i json-merge-patch), run the below code:

```
let jsonmergepatch = require("json-merge-patch");
jsonmergepatch.apply({}, JSON.parse('{ "__proto__": { "polluted": "Yes! Polluted" }}'));
console.log(polluted);
```

Outputs: Yes! Polluted.

![json-merge-patchPOC](https://user-images.githubusercontent.com/7505980/94052771-0f56bb80-fde2-11ea-9ff6-46dfc21e8824.png)


### 🔥 Proof of Fix (PoF) *

After fix execution returns: polluted is not defined

![json-merge-patchPOF](https://user-images.githubusercontent.com/7505980/94052797-17166000-fde2-11ea-82f3-f1178cad0be9.png)

### 👍 User Acceptance Testing (UAT)

After fix functionality is unafected