### PR TITLE
Fixed Prototype Pollution in json-merge-patch

### DIFF
--- a/lib/apply.js
+++ b/lib/apply.js
@@ -15,6 +15,9 @@ module.exports = function apply(target, patch) {
   var keys = Object.keys(patch);
   for (var i = 0; i < keys.length; i++) {
     var key = keys[i];
+    if (key.includes('__proto__') || key.includes('prototype') || key.includes('constructor')) {
+      return target
+    }
     if (patch[key] === null) {
       if (target.hasOwnProperty(key)) {
         delete target[key];


### PR DESCRIPTION
### 📊 Metadata *
Fixed ```Prototype Pollution``` in json-merge-patch

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-json-merge-patch

### ⚙️ Description *
```json-merge-patch``` is vulnerable to ```Prototype Pollution```. This package fails to restrict access to prototypes of objects, allowing for modification of prototype behavior using a ```proto``` payload, which may result in Information Disclosure/DoS/RCE.

### 💻 Technical Description *
Fixed Prototype pollution by filtering the keywords causing prototype pollution.

### 🐛 Proof of Concept (PoC) *
```
let jsonmergepatch = require("json-merge-patch");
jsonmergepatch.apply({}, JSON.parse('{ "__proto__": { "polluted": "Yes! Polluted" }}'));
console.log(polluted);
```
![poc](https://user-images.githubusercontent.com/29670330/94055588-c9f2b800-fdfa-11ea-854f-5c04abc80c11.png)

### 🔥 Proof of Fix (PoF) *
Fixed Prototype Pollution
![pof](https://user-images.githubusercontent.com/29670330/94055598-ceb76c00-fdfa-11ea-8974-842f9b0be6a7.png)

### 👍 User Acceptance Testing (UAT)
The App is working fine. All ok.
